### PR TITLE
fix: use promises instead of recursive loop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,9 @@ export async function untilConnected(options: Options): Promise<void> {
     try {
       return await connect(port, host)
     } catch (error) {
-      connectionError = error as Error
+      if (error instanceof Error) {
+        connectionError = error
+      }
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,9 +44,12 @@ export async function untilConnected(options: Options): Promise<void> {
   const maxRetries = options.maxRetries || 5
 
   let connectionError: Error | undefined
+
   for (let retry = 0; retry < maxRetries; retry++) {
-    if (retry && options.connectionInterval) {
-      await new Promise<void>((resolve) => setTimeout(resolve, options.connectionInterval))
+    if (retry && 'connectionInterval' in options) {
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, options.connectionInterval)
+      )
     }
     try {
       return await connect(port, host)
@@ -56,7 +59,9 @@ export async function untilConnected(options: Options): Promise<void> {
   }
 
   throw new Error(
-    `Failed to await connection at ${host || ''}:${port}. Connection never established (retries: ${maxRetries}).`,
+    `Failed to await connection at ${
+      host || ''
+    }:${port}. Connection never established (retries: ${maxRetries}).`,
     { cause: connectionError }
   )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export async function untilConnected(options: Options): Promise<void> {
   const { port, host } = resolveConnectionOptions(options)
   const maxRetries = options.maxRetries || 5
 
-  let connectionError = null
+  let connectionError: Error | undefined
   for (let retry = 0; retry < maxRetries; retry++) {
     if (retry && options.connectionInterval) {
       await new Promise<void>((resolve) => setTimeout(resolve, options.connectionInterval))
@@ -51,7 +51,7 @@ export async function untilConnected(options: Options): Promise<void> {
     try {
       return await connect(port, host)
     } catch (error) {
-      connectionError = error
+      connectionError = error as Error
     }
   }
 


### PR DESCRIPTION
Refactor connection retry mechanism:
- Replace recursive retry calls with a loop
- Replace Promise callbacks with async/await